### PR TITLE
disable pre-flight checks

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get install -y curl
 WORKDIR /home/node
 USER node
 
+ENV PREFLIGHT_CHECKS_ENABLED=false
 ENV ACCEPT=/home/node/accept.json
 COPY ./accept.json /home/node/
 COPY ./start /home/node/start


### PR DESCRIPTION
Currently our clients do not have connectivity to the server health check, so the pre flight checks are failing. This disables them for the moment to get things working.