### PR TITLE
Add paths to accept.json for k8s plugin

### DIFF
--- a/dockerfiles/kubernetes/accept.json
+++ b/dockerfiles/kubernetes/accept.json
@@ -126,6 +126,51 @@
         "scheme": "bearer",
         "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
       }
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/limitranges*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/batch/v1/jobs*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/batch/v1/cronjobs*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/apps/v1/statefulsets*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/apis/apps/v1/daemonsets*",
+      "origin": "${CLUSTER_ENDPOINT}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${K8S_SERVICE_ACCOUNT_TOKEN}"
+      }
     }
   ]
 }


### PR DESCRIPTION
These are requested by the plugin if the resources are specified which we currently give customers the option to do. However they are currently returning 401s. 

https://app.shortcut.com/larder/story/15420/tavisca-k8s-403s-via-broker