### PR TITLE
Remove broker version pinning

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && apt install -y make python gcc
 RUN apt-get update && apt-get install -y ca-certificates
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin
-RUN npm install --global snyk-broker@4.156.1
+RUN npm install --global snyk-broker
 FROM snyk/ubuntu
 ENV PATH=$PATH:/home/node/.npm-global/bin
 COPY --from=base /home/node/.npm-global /home/node/.npm-global


### PR DESCRIPTION
* Tested on internal Jenkins against demo2 instance.
* Connections flow through as expected.

Version `4.157.5`
![image](https://github.com/RoadieHQ/roadie-agent/assets/2392775/2e91e2d1-cbb3-49b9-83f7-de1d299e0b0c)


Traffic coming through as expected:
![image](https://github.com/RoadieHQ/roadie-agent/assets/2392775/abe2d289-7b88-4187-8681-d0f11275dc9d)
