### PR TITLE
Remove tough-cookie from the img

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -14,6 +14,10 @@ RUN npm install --global snyk-broker
 RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/setheader/node_modules/debug
 
 
+RUN rm -rf /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules/tough-cookie
+RUN npm i -g tough-cookie@4.1.3
+RUN mv /home/node/.npm-global/lib/node_modules/tough-cookie /home/node/.npm-global/lib/node_modules/snyk-broker/node_modules
+
 FROM roadiehq/broker:base
 ENV PATH=$PATH:/home/node/.npm-global/bin
 COPY --from=base /home/node/.npm-global /home/node/.npm-global

--- a/dockerfiles/base.Dockerfile
+++ b/dockerfiles/base.Dockerfile
@@ -8,7 +8,7 @@ RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node \
   && apt update && apt upgrade -y && apt install gpg curl xz-utils -y
 
-ENV NODE_VERSION 18.16.1
+ENV NODE_VERSION 18.17.1
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \


### PR DESCRIPTION
Manually remove tough-cookie dependency so we can remove false positive security alerts from the image and satisfy automatic scanners...