### PR TITLE
Add path to argocd

### DIFF
--- a/dockerfiles/argocd/accept.json
+++ b/dockerfiles/argocd/accept.json
@@ -27,6 +27,15 @@
     },
     {
       "method": "GET",
+      "path": "/api/applications/*",
+      "origin": "${ARGOCD_URL}",
+      "auth": {
+        "scheme": "bearer",
+        "token": "${ARGOCD_AUTH_TOKEN}"
+      }
+    },
+    {
+      "method": "GET",
       "path": "/argoInstance/*",
       "origin": "${ARGOCD_URL}",
       "auth": {


### PR DESCRIPTION
Looks like requests are coming in to  /api/proxy/argocd/api/applications/...  which isn't matching any paths